### PR TITLE
fix: 调用next(...)重定向不会触发router.afterEach钩子

### DIFF
--- a/vue-materials/scaffolds/d2-admin-ice/src/router/index.js
+++ b/vue-materials/scaffolds/d2-admin-ice/src/router/index.js
@@ -43,6 +43,7 @@ router.beforeEach((to, from, next) => {
       next({
         name: 'login'
       })
+      NProgress.done() // next(...)重定向不会触发router.afterEach钩子，需要手动hack一下
     }
   } else {
     // 不需要身份校验 直接通过


### PR DESCRIPTION
在未登录状态下，在地址栏输入需要登录后才能访问的页面url，应用会重定向至 login。但是这时顶部的 NProgress 依然在加载中，因为`next(...)`重定向不会触发`router.afterEach`钩子，这里需要手动 hack 一下。